### PR TITLE
Copy files from Go 1.19.2

### DIFF
--- a/all_test.go
+++ b/all_test.go
@@ -372,6 +372,9 @@ var literalPrefixTests = []MetaTest{
 	{`^^0$$`, ``, ``, false},
 	{`^$^$`, ``, ``, false},
 	{`$$0^^`, ``, ``, false},
+	{`a\x{fffd}b`, ``, `a`, false},
+	{`\x{fffd}b`, ``, ``, false},
+	{"\ufffd", ``, ``, false},
 }
 
 func TestQuoteMeta(t *testing.T) {

--- a/backtrack.go
+++ b/backtrack.go
@@ -163,7 +163,7 @@ func (re *Regexp) tryBacktrack(b *bitState, i input, pc uint32, pos int) bool {
 		}
 	Skip:
 
-		inst := re.prog.Inst[pc]
+		inst := &re.prog.Inst[pc]
 
 		switch inst.Op {
 		default:

--- a/exec.go
+++ b/exec.go
@@ -427,7 +427,7 @@ func (re *Regexp) doOnePass(ir io.RuneReader, ib []byte, is string, pos, ncap in
 		flag = i.context(pos)
 	}
 	pc := re.onepass.Start
-	inst := re.onepass.Inst[pc]
+	inst := &re.onepass.Inst[pc]
 	// If there is a simple literal prefix, skip over it.
 	if pos == 0 && flag.match(syntax.EmptyOp(inst.Arg)) &&
 		len(re.prefix) > 0 && i.canCheckPrefix() {
@@ -442,7 +442,7 @@ func (re *Regexp) doOnePass(ir io.RuneReader, ib []byte, is string, pos, ncap in
 		pc = int(re.prefixEnd)
 	}
 	for {
-		inst = re.onepass.Inst[pc]
+		inst = &re.onepass.Inst[pc]
 		pc = int(inst.Out)
 		switch inst.Op {
 		default:
@@ -470,7 +470,7 @@ func (re *Regexp) doOnePass(ir io.RuneReader, ib []byte, is string, pos, ncap in
 			}
 		// peek at the input rune to see which branch of the Alt to take
 		case syntax.InstAlt, syntax.InstAltMatch:
-			pc = int(onePassNext(&inst, r))
+			pc = int(onePassNext(inst, r))
 			continue
 		case syntax.InstFail:
 			goto Return

--- a/exec2_test.go
+++ b/exec2_test.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build !race
-// +build !race
 
 package regexp
 

--- a/exec_test.go
+++ b/exec_test.go
@@ -8,6 +8,7 @@ import (
 	"bufio"
 	"compress/bzip2"
 	"fmt"
+	"internal/testenv"
 	"io"
 	"os"
 	"path/filepath"
@@ -51,8 +52,8 @@ import (
 // submatch indices. An unmatched subexpression formats
 // its pair as a single - (not illustrated above).  For now
 // each regexp run produces two match results, one for a
-// ``full match'' that restricts the regexp to matching the entire
-// string or nothing, and one for a ``partial match'' that gives
+// “full match” that restricts the regexp to matching the entire
+// string or nothing, and one for a “partial match” that gives
 // the leftmost first match found in the string.
 //
 // Lines beginning with # are comments. Lines beginning with
@@ -61,7 +62,6 @@ import (
 //
 // At time of writing, re2-exhaustive.txt is 59 MB but compresses to 385 kB,
 // so we store re2-exhaustive.txt.bz2 in the repository and decompress it on the fly.
-//
 func TestRE2Search(t *testing.T) {
 	testRE2(t, "testdata/re2-search.txt")
 }
@@ -293,12 +293,9 @@ func parseResult(t *testing.T, file string, lineno int, res string) []int {
 				out[n] = -1
 				out[n+1] = -1
 			} else {
-				k := strings.Index(pair, "-")
-				if k < 0 {
-					t.Fatalf("%s:%d: invalid pair %s", file, lineno, pair)
-				}
-				lo, err1 := strconv.Atoi(pair[:k])
-				hi, err2 := strconv.Atoi(pair[k+1:])
+				loStr, hiStr, _ := strings.Cut(pair, "-")
+				lo, err1 := strconv.Atoi(loStr)
+				hi, err2 := strconv.Atoi(hiStr)
 				if err1 != nil || err2 != nil || lo > hi {
 					t.Fatalf("%s:%d: invalid pair %s", file, lineno, pair)
 				}
@@ -456,12 +453,11 @@ Reading:
 				continue Reading
 			}
 		case ':':
-			i := strings.Index(flag[1:], ":")
-			if i < 0 {
+			var ok bool
+			if _, flag, ok = strings.Cut(flag[1:], ":"); !ok {
 				t.Logf("skip: %s", line)
 				continue Reading
 			}
-			flag = flag[1+i+1:]
 		case 'C', 'N', 'T', '0', '1', '2', '3', '4', '5', '6', '7', '8', '9':
 			t.Logf("skip: %s", line)
 			continue Reading
@@ -659,7 +655,7 @@ func makeText(n int) []byte {
 }
 
 func BenchmarkMatch(b *testing.B) {
-	isRaceBuilder := strings.HasSuffix(builder(), "-race")
+	isRaceBuilder := strings.HasSuffix(testenv.Builder(), "-race")
 
 	for _, data := range benchData {
 		r := MustCompile(data.re)
@@ -681,7 +677,7 @@ func BenchmarkMatch(b *testing.B) {
 }
 
 func BenchmarkMatch_onepass_regex(b *testing.B) {
-	isRaceBuilder := strings.HasSuffix(builder(), "-race")
+	isRaceBuilder := strings.HasSuffix(testenv.Builder(), "-race")
 	r := MustCompile(`(?s)\A.*\z`)
 	if r.onepass == nil {
 		b.Fatalf("want onepass regex, but %q is not onepass", r)
@@ -701,10 +697,6 @@ func BenchmarkMatch_onepass_regex(b *testing.B) {
 			}
 		})
 	}
-}
-
-func builder() string {
-	return os.Getenv("GO_BUILDER_NAME")
 }
 
 var benchData = []struct{ name, re string }{

--- a/find_test.go
+++ b/find_test.go
@@ -116,6 +116,13 @@ var findTests = []FindTest{
 	{"\\`", "`", build(1, 0, 1)},
 	{"[\\`]+", "`", build(1, 0, 1)},
 
+	{"\ufffd", "\xff", build(1, 0, 1)},
+	{"\ufffd", "hello\xffworld", build(1, 5, 6)},
+	{`.*`, "hello\xffworld", build(1, 0, 11)},
+	{`\x{fffd}`, "\xc2\x00", build(1, 0, 1)},
+	{"[\ufffd]", "\xff", build(1, 0, 1)},
+	{`[\x{fffd}]`, "\xc2\x00", build(1, 0, 1)},
+
 	// long set of matches (longer than startSize)
 	{
 		".",

--- a/onepass.go
+++ b/onepass.go
@@ -9,6 +9,7 @@ import (
 	"sort"
 	"strings"
 	"unicode"
+	"unicode/utf8"
 )
 
 // "One-pass" regexp execution.
@@ -55,7 +56,7 @@ func onePassPrefix(p *syntax.Prog) (prefix string, complete bool, pc uint32) {
 
 	// Have prefix; gather characters.
 	var buf strings.Builder
-	for iop(i) == syntax.InstRune && len(i.Rune) == 1 && syntax.Flags(i.Arg)&syntax.FoldCase == 0 {
+	for iop(i) == syntax.InstRune && len(i.Rune) == 1 && syntax.Flags(i.Arg)&syntax.FoldCase == 0 && i.Rune[0] != utf8.RuneError {
 		buf.WriteRune(i.Rune[0])
 		pc, i = i.Out, &p.Inst[i.Out]
 	}

--- a/regexp.go
+++ b/regexp.go
@@ -9,17 +9,22 @@
 // More precisely, it is the syntax accepted by RE2 and described at
 // https://golang.org/s/re2syntax, except for \C.
 // For an overview of the syntax, run
-//   go doc regexp/syntax
+//
+//	go doc regexp/syntax
 //
 // The regexp implementation provided by this package is
 // guaranteed to run in time linear in the size of the input.
 // (This is a property not guaranteed by most open source
 // implementations of regular expressions.) For more information
 // about this property, see
+//
 //	https://swtch.com/~rsc/regexp/regexp1.html
+//
 // or any book about automata theory.
 //
 // All characters are UTF-8-encoded code points.
+// Following utf8.DecodeRune, each byte of an invalid UTF-8 sequence
+// is treated as if it encoded utf8.RuneError (U+FFFD).
 //
 // There are 16 methods of Regexp that match a regular expression and identify
 // the matched text. Their names are matched by this regular expression:
@@ -40,11 +45,11 @@
 // successive submatches of the expression. Submatches are matches of
 // parenthesized subexpressions (also known as capturing groups) within the
 // regular expression, numbered from left to right in order of opening
-// parenthesis. Submatch 0 is the match of the entire expression, submatch 1
+// parenthesis. Submatch 0 is the match of the entire expression, submatch 1 is
 // the match of the first parenthesized subexpression, and so on.
 //
 // If 'Index' is present, matches and submatches are identified by byte index
-// pairs within the input string: result[2*n:2*n+1] identifies the indexes of
+// pairs within the input string: result[2*n:2*n+2] identifies the indexes of
 // the nth submatch. The pair for n==0 identifies the match of the entire
 // expression. If 'Index' is not present, the match is identified by the text
 // of the match/submatch. If an index is negative or text is nil, it means that
@@ -62,7 +67,6 @@
 // before returning.
 //
 // (There are a few other methods that do not match this pattern.)
-//
 package regexp
 
 import (
@@ -276,7 +280,11 @@ func minInputLen(re *syntax.Regexp) int {
 	case syntax.OpLiteral:
 		l := 0
 		for _, r := range re.Rune {
-			l += utf8.RuneLen(r)
+			if r == utf8.RuneError {
+				l++
+			} else {
+				l += utf8.RuneLen(r)
+			}
 		}
 		return l
 	case syntax.OpCapture, syntax.OpPlus:
@@ -787,11 +795,12 @@ func (re *Regexp) allMatches(s string, b []byte, n int, deliver func([]int)) {
 				accept = false
 			}
 			var width int
-			// TODO: use step()
 			if b == nil {
-				_, width = utf8.DecodeRuneInString(s[pos:end])
+				is := inputString{str: s}
+				_, width = is.step(pos)
 			} else {
-				_, width = utf8.DecodeRune(b[pos:end])
+				ib := inputBytes{str: b}
+				_, width = ib.step(pos)
 			}
 			if width > 0 {
 				pos += width
@@ -922,23 +931,22 @@ func (re *Regexp) ExpandString(dst []byte, template string, src string, match []
 
 func (re *Regexp) expand(dst []byte, template string, bsrc []byte, src string, match []int) []byte {
 	for len(template) > 0 {
-		i := strings.Index(template, "$")
-		if i < 0 {
+		before, after, ok := strings.Cut(template, "$")
+		if !ok {
 			break
 		}
-		dst = append(dst, template[:i]...)
-		template = template[i:]
-		if len(template) > 1 && template[1] == '$' {
+		dst = append(dst, before...)
+		template = after
+		if template != "" && template[0] == '$' {
 			// Treat $$ as $.
 			dst = append(dst, '$')
-			template = template[2:]
+			template = template[1:]
 			continue
 		}
 		name, num, rest, ok := extract(template)
 		if !ok {
 			// Malformed; treat $ as raw text.
 			dst = append(dst, '$')
-			template = template[1:]
 			continue
 		}
 		template = rest
@@ -967,17 +975,16 @@ func (re *Regexp) expand(dst []byte, template string, bsrc []byte, src string, m
 	return dst
 }
 
-// extract returns the name from a leading "$name" or "${name}" in str.
+// extract returns the name from a leading "name" or "{name}" in str.
+// (The $ has already been removed by the caller.)
 // If it is a number, extract returns num set to that number; otherwise num = -1.
 func extract(str string) (name string, num int, rest string, ok bool) {
-	if len(str) < 2 || str[0] != '$' {
+	if str == "" {
 		return
 	}
 	brace := false
-	if str[1] == '{' {
+	if str[0] == '{' {
 		brace = true
-		str = str[2:]
-	} else {
 		str = str[1:]
 	}
 	i := 0
@@ -1234,13 +1241,15 @@ func (re *Regexp) FindAllStringSubmatchIndex(s string, n int) [][]int {
 // that contains no metacharacters, it is equivalent to strings.SplitN.
 //
 // Example:
-//   s := regexp.MustCompile("a*").Split("abaabaccadaaae", 5)
-//   // s: ["", "b", "b", "c", "cadaaae"]
+//
+//	s := regexp.MustCompile("a*").Split("abaabaccadaaae", 5)
+//	// s: ["", "b", "b", "c", "cadaaae"]
 //
 // The count determines the number of substrings to return:
-//   n > 0: at most n substrings; the last substring will be the unsplit remainder.
-//   n == 0: the result is nil (zero substrings)
-//   n < 0: all substrings
+//
+//	n > 0: at most n substrings; the last substring will be the unsplit remainder.
+//	n == 0: the result is nil (zero substrings)
+//	n < 0: all substrings
 func (re *Regexp) Split(s string, n int) []string {
 
 	if n == 0 {

--- a/syntax/doc.go
+++ b/syntax/doc.go
@@ -9,123 +9,132 @@ Package syntax parses regular expressions into parse trees and compiles
 parse trees into programs. Most clients of regular expressions will use the
 facilities of package regexp (such as Compile and Match) instead of this package.
 
-Syntax
+# Syntax
 
 The regular expression syntax understood by this package when parsing with the Perl flag is as follows.
 Parts of the syntax can be disabled by passing alternate flags to Parse.
 
-
 Single characters:
-  .              any character, possibly including newline (flag s=true)
-  [xyz]          character class
-  [^xyz]         negated character class
-  \d             Perl character class
-  \D             negated Perl character class
-  [[:alpha:]]    ASCII character class
-  [[:^alpha:]]   negated ASCII character class
-  \pN            Unicode character class (one-letter name)
-  \p{Greek}      Unicode character class
-  \PN            negated Unicode character class (one-letter name)
-  \P{Greek}      negated Unicode character class
+
+	.              any character, possibly including newline (flag s=true)
+	[xyz]          character class
+	[^xyz]         negated character class
+	\d             Perl character class
+	\D             negated Perl character class
+	[[:alpha:]]    ASCII character class
+	[[:^alpha:]]   negated ASCII character class
+	\pN            Unicode character class (one-letter name)
+	\p{Greek}      Unicode character class
+	\PN            negated Unicode character class (one-letter name)
+	\P{Greek}      negated Unicode character class
 
 Composites:
-  xy             x followed by y
-  x|y            x or y (prefer x)
+
+	xy             x followed by y
+	x|y            x or y (prefer x)
 
 Repetitions:
-  x*             zero or more x, prefer more
-  x+             one or more x, prefer more
-  x?             zero or one x, prefer one
-  x{n,m}         n or n+1 or ... or m x, prefer more
-  x{n,}          n or more x, prefer more
-  x{n}           exactly n x
-  x*?            zero or more x, prefer fewer
-  x+?            one or more x, prefer fewer
-  x??            zero or one x, prefer zero
-  x{n,m}?        n or n+1 or ... or m x, prefer fewer
-  x{n,}?         n or more x, prefer fewer
-  x{n}?          exactly n x
+
+	x*             zero or more x, prefer more
+	x+             one or more x, prefer more
+	x?             zero or one x, prefer one
+	x{n,m}         n or n+1 or ... or m x, prefer more
+	x{n,}          n or more x, prefer more
+	x{n}           exactly n x
+	x*?            zero or more x, prefer fewer
+	x+?            one or more x, prefer fewer
+	x??            zero or one x, prefer zero
+	x{n,m}?        n or n+1 or ... or m x, prefer fewer
+	x{n,}?         n or more x, prefer fewer
+	x{n}?          exactly n x
 
 Implementation restriction: The counting forms x{n,m}, x{n,}, and x{n}
 reject forms that create a minimum or maximum repetition count above 1000.
 Unlimited repetitions are not subject to this restriction.
 
 Grouping:
-  (re)           numbered capturing group (submatch)
-  (?P<name>re)   named & numbered capturing group (submatch)
-  (?:re)         non-capturing group
-  (?flags)       set flags within current group; non-capturing
-  (?flags:re)    set flags during re; non-capturing
 
-  Flag syntax is xyz (set) or -xyz (clear) or xy-z (set xy, clear z). The flags are:
+	(re)           numbered capturing group (submatch)
+	(?P<name>re)   named & numbered capturing group (submatch)
+	(?:re)         non-capturing group
+	(?flags)       set flags within current group; non-capturing
+	(?flags:re)    set flags during re; non-capturing
 
-  i              case-insensitive (default false)
-  m              multi-line mode: ^ and $ match begin/end line in addition to begin/end text (default false)
-  s              let . match \n (default false)
-  U              ungreedy: swap meaning of x* and x*?, x+ and x+?, etc (default false)
+	Flag syntax is xyz (set) or -xyz (clear) or xy-z (set xy, clear z). The flags are:
+
+	i              case-insensitive (default false)
+	m              multi-line mode: ^ and $ match begin/end line in addition to begin/end text (default false)
+	s              let . match \n (default false)
+	U              ungreedy: swap meaning of x* and x*?, x+ and x+?, etc (default false)
 
 Empty strings:
-  ^              at beginning of text or line (flag m=true)
-  $              at end of text (like \z not \Z) or line (flag m=true)
-  \A             at beginning of text
-  \b             at ASCII word boundary (\w on one side and \W, \A, or \z on the other)
-  \B             not at ASCII word boundary
-  \z             at end of text
+
+	^              at beginning of text or line (flag m=true)
+	$              at end of text (like \z not \Z) or line (flag m=true)
+	\A             at beginning of text
+	\b             at ASCII word boundary (\w on one side and \W, \A, or \z on the other)
+	\B             not at ASCII word boundary
+	\z             at end of text
 
 Escape sequences:
-  \a             bell (== \007)
-  \f             form feed (== \014)
-  \t             horizontal tab (== \011)
-  \n             newline (== \012)
-  \r             carriage return (== \015)
-  \v             vertical tab character (== \013)
-  \*             literal *, for any punctuation character *
-  \123           octal character code (up to three digits)
-  \x7F           hex character code (exactly two digits)
-  \x{10FFFF}     hex character code
-  \Q...\E        literal text ... even if ... has punctuation
+
+	\a             bell (== \007)
+	\f             form feed (== \014)
+	\t             horizontal tab (== \011)
+	\n             newline (== \012)
+	\r             carriage return (== \015)
+	\v             vertical tab character (== \013)
+	\*             literal *, for any punctuation character *
+	\123           octal character code (up to three digits)
+	\x7F           hex character code (exactly two digits)
+	\x{10FFFF}     hex character code
+	\Q...\E        literal text ... even if ... has punctuation
 
 Character class elements:
-  x              single character
-  A-Z            character range (inclusive)
-  \d             Perl character class
-  [:foo:]        ASCII character class foo
-  \p{Foo}        Unicode character class Foo
-  \pF            Unicode character class F (one-letter name)
+
+	x              single character
+	A-Z            character range (inclusive)
+	\d             Perl character class
+	[:foo:]        ASCII character class foo
+	\p{Foo}        Unicode character class Foo
+	\pF            Unicode character class F (one-letter name)
 
 Named character classes as character class elements:
-  [\d]           digits (== \d)
-  [^\d]          not digits (== \D)
-  [\D]           not digits (== \D)
-  [^\D]          not not digits (== \d)
-  [[:name:]]     named ASCII class inside character class (== [:name:])
-  [^[:name:]]    named ASCII class inside negated character class (== [:^name:])
-  [\p{Name}]     named Unicode property inside character class (== \p{Name})
-  [^\p{Name}]    named Unicode property inside negated character class (== \P{Name})
+
+	[\d]           digits (== \d)
+	[^\d]          not digits (== \D)
+	[\D]           not digits (== \D)
+	[^\D]          not not digits (== \d)
+	[[:name:]]     named ASCII class inside character class (== [:name:])
+	[^[:name:]]    named ASCII class inside negated character class (== [:^name:])
+	[\p{Name}]     named Unicode property inside character class (== \p{Name})
+	[^\p{Name}]    named Unicode property inside negated character class (== \P{Name})
 
 Perl character classes (all ASCII-only):
-  \d             digits (== [0-9])
-  \D             not digits (== [^0-9])
-  \s             whitespace (== [\t\n\f\r ])
-  \S             not whitespace (== [^\t\n\f\r ])
-  \w             word characters (== [0-9A-Za-z_])
-  \W             not word characters (== [^0-9A-Za-z_])
+
+	\d             digits (== [0-9])
+	\D             not digits (== [^0-9])
+	\s             whitespace (== [\t\n\f\r ])
+	\S             not whitespace (== [^\t\n\f\r ])
+	\w             word characters (== [0-9A-Za-z_])
+	\W             not word characters (== [^0-9A-Za-z_])
 
 ASCII character classes:
-  [[:alnum:]]    alphanumeric (== [0-9A-Za-z])
-  [[:alpha:]]    alphabetic (== [A-Za-z])
-  [[:ascii:]]    ASCII (== [\x00-\x7F])
-  [[:blank:]]    blank (== [\t ])
-  [[:cntrl:]]    control (== [\x00-\x1F\x7F])
-  [[:digit:]]    digits (== [0-9])
-  [[:graph:]]    graphical (== [!-~] == [A-Za-z0-9!"#$%&'()*+,\-./:;<=>?@[\\\]^_`{|}~])
-  [[:lower:]]    lower case (== [a-z])
-  [[:print:]]    printable (== [ -~] == [ [:graph:]])
-  [[:punct:]]    punctuation (== [!-/:-@[-`{-~])
-  [[:space:]]    whitespace (== [\t\n\v\f\r ])
-  [[:upper:]]    upper case (== [A-Z])
-  [[:word:]]     word characters (== [0-9A-Za-z_])
-  [[:xdigit:]]   hex digit (== [0-9A-Fa-f])
+
+	[[:alnum:]]    alphanumeric (== [0-9A-Za-z])
+	[[:alpha:]]    alphabetic (== [A-Za-z])
+	[[:ascii:]]    ASCII (== [\x00-\x7F])
+	[[:blank:]]    blank (== [\t ])
+	[[:cntrl:]]    control (== [\x00-\x1F\x7F])
+	[[:digit:]]    digits (== [0-9])
+	[[:graph:]]    graphical (== [!-~] == [A-Za-z0-9!"#$%&'()*+,\-./:;<=>?@[\\\]^_`{|}~])
+	[[:lower:]]    lower case (== [a-z])
+	[[:print:]]    printable (== [ -~] == [ [:graph:]])
+	[[:punct:]]    punctuation (== [!-/:-@[-`{-~])
+	[[:space:]]    whitespace (== [\t\n\v\f\r ])
+	[[:upper:]]    upper case (== [A-Z])
+	[[:word:]]     word characters (== [0-9A-Za-z_])
+	[[:xdigit:]]   hex digit (== [0-9A-Fa-f])
 
 Unicode character classes are those in unicode.Categories and unicode.Scripts.
 */

--- a/syntax/parse.go
+++ b/syntax/parse.go
@@ -43,6 +43,7 @@ const (
 	ErrMissingRepeatArgument ErrorCode = "missing argument to repetition operator"
 	ErrTrailingBackslash     ErrorCode = "trailing backslash at end of expression"
 	ErrUnexpectedParen       ErrorCode = "unexpected )"
+	ErrNestingDepth          ErrorCode = "expression nests too deeply"
 )
 
 func (e ErrorCode) String() string {
@@ -90,15 +91,49 @@ const (
 // until we've allocated at least maxHeight Regexp structures.
 const maxHeight = 1000
 
+// maxSize is the maximum size of a compiled regexp in Insts.
+// It too is somewhat arbitrarily chosen, but the idea is to be large enough
+// to allow significant regexps while at the same time small enough that
+// the compiled form will not take up too much memory.
+// 128 MB is enough for a 3.3 million Inst structures, which roughly
+// corresponds to a 3.3 MB regexp.
+const (
+	maxSize  = 128 << 20 / instSize
+	instSize = 5 * 8 // byte, 2 uint32, slice is 5 64-bit words
+)
+
+// maxRunes is the maximum number of runes allowed in a regexp tree
+// counting the runes in all the nodes.
+// Ignoring character classes p.numRunes is always less than the length of the regexp.
+// Character classes can make it much larger: each \pL adds 1292 runes.
+// 128 MB is enough for 32M runes, which is over 26k \pL instances.
+// Note that repetitions do not make copies of the rune slices,
+// so \pL{1000} is only one rune slice, not 1000.
+// We could keep a cache of character classes we've seen,
+// so that all the \pL we see use the same rune list,
+// but that doesn't remove the problem entirely:
+// consider something like [\pL01234][\pL01235][\pL01236]...[\pL^&*()].
+// And because the Rune slice is exposed directly in the Regexp,
+// there is not an opportunity to change the representation to allow
+// partial sharing between different character classes.
+// So the limit is the best we can do.
+const (
+	maxRunes = 128 << 20 / runeSize
+	runeSize = 4 // rune is int32
+)
+
 type parser struct {
 	flags       Flags     // parse mode flags
 	stack       []*Regexp // stack of parsed expressions
 	free        *Regexp
 	numCap      int // number of capturing groups seen
 	wholeRegexp string
-	tmpClass    []rune          // temporary char class work space
-	numRegexp   int             // number of regexps allocated
-	height      map[*Regexp]int // regexp height for height limit check
+	tmpClass    []rune            // temporary char class work space
+	numRegexp   int               // number of regexps allocated
+	numRunes    int               // number of runes in char classes
+	repeats     int64             // product of all repetitions seen
+	height      map[*Regexp]int   // regexp height, for height limit check
+	size        map[*Regexp]int64 // regexp compiled size, for size limit check
 }
 
 func (p *parser) newRegexp(op Op) *Regexp {
@@ -122,6 +157,104 @@ func (p *parser) reuse(re *Regexp) {
 	p.free = re
 }
 
+func (p *parser) checkLimits(re *Regexp) {
+	if p.numRunes > maxRunes {
+		panic(ErrInternalError)
+	}
+	p.checkSize(re)
+	p.checkHeight(re)
+}
+
+func (p *parser) checkSize(re *Regexp) {
+	if p.size == nil {
+		// We haven't started tracking size yet.
+		// Do a relatively cheap check to see if we need to start.
+		// Maintain the product of all the repeats we've seen
+		// and don't track if the total number of regexp nodes
+		// we've seen times the repeat product is in budget.
+		if p.repeats == 0 {
+			p.repeats = 1
+		}
+		if re.Op == OpRepeat {
+			n := re.Max
+			if n == -1 {
+				n = re.Min
+			}
+			if n <= 0 {
+				n = 1
+			}
+			if int64(n) > maxSize/p.repeats {
+				p.repeats = maxSize
+			} else {
+				p.repeats *= int64(n)
+			}
+		}
+		if int64(p.numRegexp) < maxSize/p.repeats {
+			return
+		}
+
+		// We need to start tracking size.
+		// Make the map and belatedly populate it
+		// with info about everything we've constructed so far.
+		p.size = make(map[*Regexp]int64)
+		for _, re := range p.stack {
+			p.checkSize(re)
+		}
+	}
+
+	if p.calcSize(re, true) > maxSize {
+		panic(ErrInternalError)
+	}
+}
+
+func (p *parser) calcSize(re *Regexp, force bool) int64 {
+	if !force {
+		if size, ok := p.size[re]; ok {
+			return size
+		}
+	}
+
+	var size int64
+	switch re.Op {
+	case OpLiteral:
+		size = int64(len(re.Rune))
+	case OpCapture, OpStar:
+		// star can be 1+ or 2+; assume 2 pessimistically
+		size = 2 + p.calcSize(re.Sub[0], false)
+	case OpPlus, OpQuest:
+		size = 1 + p.calcSize(re.Sub[0], false)
+	case OpConcat:
+		for _, sub := range re.Sub {
+			size += p.calcSize(sub, false)
+		}
+	case OpAlternate:
+		for _, sub := range re.Sub {
+			size += p.calcSize(sub, false)
+		}
+		if len(re.Sub) > 1 {
+			size += int64(len(re.Sub)) - 1
+		}
+	case OpRepeat:
+		sub := p.calcSize(re.Sub[0], false)
+		if re.Max == -1 {
+			if re.Min == 0 {
+				size = 2 + sub // x*
+			} else {
+				size = 1 + int64(re.Min)*sub // xxx+
+			}
+			break
+		}
+		// x{2,5} = xx(x(x(x)?)?)?
+		size = int64(re.Max)*sub + int64(re.Max-re.Min)
+	}
+
+	if size < 1 {
+		size = 1
+	}
+	p.size[re] = size
+	return size
+}
+
 func (p *parser) checkHeight(re *Regexp) {
 	if p.numRegexp < maxHeight {
 		return
@@ -133,7 +266,7 @@ func (p *parser) checkHeight(re *Regexp) {
 		}
 	}
 	if p.calcHeight(re, true) > maxHeight {
-		panic(ErrInternalError)
+		panic(ErrNestingDepth)
 	}
 }
 
@@ -158,6 +291,7 @@ func (p *parser) calcHeight(re *Regexp, force bool) int {
 
 // push pushes the regexp re onto the parse stack and returns the regexp.
 func (p *parser) push(re *Regexp) *Regexp {
+	p.numRunes += len(re.Rune)
 	if re.Op == OpCharClass && len(re.Rune) == 2 && re.Rune[0] == re.Rune[1] {
 		// Single rune.
 		if p.maybeConcat(re.Rune[0], p.flags&^FoldCase) {
@@ -189,7 +323,7 @@ func (p *parser) push(re *Regexp) *Regexp {
 	}
 
 	p.stack = append(p.stack, re)
-	p.checkHeight(re)
+	p.checkLimits(re)
 	return re
 }
 
@@ -299,7 +433,7 @@ func (p *parser) repeat(op Op, min, max int, before, after, lastRepeat string) (
 	re.Sub = re.Sub0[:1]
 	re.Sub[0] = sub
 	p.stack[n-1] = re
-	p.checkHeight(re)
+	p.checkLimits(re)
 
 	if op == OpRepeat && (min >= 2 || max >= 2) && !repeatIsValid(re, 1000) {
 		return "", &Error{ErrInvalidRepeatSize, before[:len(before)-len(after)]}
@@ -444,12 +578,16 @@ func (p *parser) collapse(subs []*Regexp, op Op) *Regexp {
 // frees (passes to p.reuse) any removed *Regexps.
 //
 // For example,
-//     ABC|ABD|AEF|BCX|BCY
-// simplifies by literal prefix extraction to
-//     A(B(C|D)|EF)|BC(X|Y)
-// which simplifies by character class introduction to
-//     A(B[CD]|EF)|BC[XY]
 //
+//	ABC|ABD|AEF|BCX|BCY
+//
+// simplifies by literal prefix extraction to
+//
+//	A(B(C|D)|EF)|BC(X|Y)
+//
+// which simplifies by character class introduction to
+//
+//	A(B[CD]|EF)|BC[XY]
 func (p *parser) factor(sub []*Regexp) []*Regexp {
 	if len(sub) < 2 {
 		return sub
@@ -503,6 +641,7 @@ func (p *parser) factor(sub []*Regexp) []*Regexp {
 
 			for j := start; j < i; j++ {
 				sub[j] = p.removeLeadingString(sub[j], len(str))
+				p.checkLimits(sub[j])
 			}
 			suffix := p.collapse(sub[start:i], OpAlternate) // recurse
 
@@ -560,6 +699,7 @@ func (p *parser) factor(sub []*Regexp) []*Regexp {
 			for j := start; j < i; j++ {
 				reuse := j != start // prefix came from sub[start]
 				sub[j] = p.removeLeadingRegexp(sub[j], reuse)
+				p.checkLimits(sub[j])
 			}
 			suffix := p.collapse(sub[start:i], OpAlternate) // recurse
 
@@ -757,8 +897,10 @@ func parse(s string, flags Flags) (_ *Regexp, err error) {
 			panic(r)
 		case nil:
 			// ok
-		case ErrInternalError:
+		case ErrInternalError: // too big
 			err = &Error{Code: ErrInternalError, Expr: s}
+		case ErrNestingDepth:
+			err = &Error{Code: ErrNestingDepth, Expr: s}
 		}
 	}()
 
@@ -892,13 +1034,7 @@ func parse(s string, flags Flags) (_ *Regexp, err error) {
 				case 'Q':
 					// \Q ... \E: the ... is always literals
 					var lit string
-					if i := strings.Index(t, `\E`); i < 0 {
-						lit = t[2:]
-						t = ""
-					} else {
-						lit = t[2:i]
-						t = t[i+2:]
-					}
+					lit, t, _ = strings.Cut(t[2:], `\E`)
 					for lit != "" {
 						c, rest, err := nextRune(lit)
 						if err != nil {

--- a/syntax/parse_test.go
+++ b/syntax/parse_test.go
@@ -484,12 +484,15 @@ var invalidRegexps = []string{
 	`(?P<>a)`,
 	`[a-Z]`,
 	`(?i)[a-Z]`,
-	`a{100000}`,
-	`a{100000,}`,
-	"((((((((((x{2}){2}){2}){2}){2}){2}){2}){2}){2}){2})",
-	strings.Repeat("(", 1000) + strings.Repeat(")", 1000),
-	strings.Repeat("(?:", 1000) + strings.Repeat(")*", 1000),
 	`\Q\E*`,
+	`a{100000}`,  // too much repetition
+	`a{100000,}`, // too much repetition
+	"((((((((((x{2}){2}){2}){2}){2}){2}){2}){2}){2}){2})",    // too much repetition
+	strings.Repeat("(", 1000) + strings.Repeat(")", 1000),    // too deep
+	strings.Repeat("(?:", 1000) + strings.Repeat(")*", 1000), // too deep
+	"(" + strings.Repeat("(xx?)", 1000) + "){1000}",          // too long
+	strings.Repeat("(xx?){1000}", 1000),                      // too long
+	strings.Repeat(`\pL`, 27000),                             // too many runes
 }
 
 var onlyPerl = []string{

--- a/syntax/prog.go
+++ b/syntax/prog.go
@@ -8,6 +8,7 @@ import (
 	"strconv"
 	"strings"
 	"unicode"
+	"unicode/utf8"
 )
 
 // Compiled program.
@@ -101,7 +102,7 @@ func EmptyOpContext(r1, r2 rune) EmptyOp {
 	return op
 }
 
-// IsWordChar reports whether r is consider a ``word character''
+// IsWordChar reports whether r is considered a “word character”
 // during the evaluation of the \b and \B zero-width assertions.
 // These assertions are ASCII-only: the word characters are [A-Za-z0-9_].
 func IsWordChar(r rune) bool {
@@ -154,7 +155,7 @@ func (p *Prog) Prefix() (prefix string, complete bool) {
 
 	// Have prefix; gather characters.
 	var buf strings.Builder
-	for i.op() == InstRune && len(i.Rune) == 1 && Flags(i.Arg)&FoldCase == 0 {
+	for i.op() == InstRune && len(i.Rune) == 1 && Flags(i.Arg)&FoldCase == 0 && i.Rune[0] != utf8.RuneError {
 		buf.WriteRune(i.Rune[0])
 		i = p.skipNop(i.Out)
 	}


### PR DESCRIPTION
This PR copies latest version of regexp package from Go 1.19.2 into `main`.