### PR TITLE
Remove usage of internal package from speedup golang 1.19.2 branch to make tests work.

### DIFF
--- a/exec_test.go
+++ b/exec_test.go
@@ -8,7 +8,6 @@ import (
 	"bufio"
 	"compress/bzip2"
 	"fmt"
-	"internal/testenv"
 	"io"
 	"os"
 	"path/filepath"
@@ -656,7 +655,7 @@ func makeText(n int) []byte {
 }
 
 func BenchmarkMatch(b *testing.B) {
-	isRaceBuilder := strings.HasSuffix(testenv.Builder(), "-race")
+	isRaceBuilder := strings.HasSuffix(builder(), "-race")
 
 	for _, data := range benchData {
 		r := MustCompile(data.re)
@@ -678,7 +677,7 @@ func BenchmarkMatch(b *testing.B) {
 }
 
 func BenchmarkMatch_onepass_regex(b *testing.B) {
-	isRaceBuilder := strings.HasSuffix(testenv.Builder(), "-race")
+	isRaceBuilder := strings.HasSuffix(builder(), "-race")
 	r := MustCompile(`(?s)\A.*\z`)
 	if r.onepass == nil {
 		b.Fatalf("want onepass regex, but %q is not onepass", r)
@@ -698,6 +697,10 @@ func BenchmarkMatch_onepass_regex(b *testing.B) {
 			}
 		})
 	}
+}
+
+func builder() string {
+	return os.Getenv("GO_BUILDER_NAME")
 }
 
 var benchData = []struct{ name, re string }{


### PR DESCRIPTION
Cherry-pick c28f921075860bcf095babc30a357bbc02c4068f into speedup-golang-1.19.2 branch.

Fixed failing tests.