### PR TITLE
speedup branch: don't sort alternates with different case-folding

### DIFF
--- a/find_test.go
+++ b/find_test.go
@@ -67,6 +67,14 @@ var findTests = []FindTest{
 	{`/$`, "/abc/", build(1, 4, 5)},
 	{`/$`, "/abc", nil},
 
+	// lists of alternates, with prefix in common
+	{`xx|aa|a`, "aa", build(1, 0, 2)},
+	{`xx|aa|(?i:a)`, "aa", build(1, 0, 2)},
+	{`xx|a|aa`, "aa", build(2, 0, 1, 1, 2)},
+	{`xx|(?i:a)|aa`, "aa", build(2, 0, 1, 1, 2)},
+	{`xx|a|(?i:aa)`, "aa", build(2, 0, 1, 1, 2)},
+	{`xx|(?i:a)|(?i:aa)`, "aa", build(2, 0, 1, 1, 2)},
+
 	// multiple matches
 	{`.`, "abc", build(3, 0, 1, 1, 2, 2, 3)},
 	{`(.)`, "abc", build(3, 0, 1, 0, 1, 1, 2, 1, 2, 2, 3, 2, 3)},

--- a/syntax/parse.go
+++ b/syntax/parse.go
@@ -593,14 +593,17 @@ func (p *parser) factor(sub []*Regexp) []*Regexp {
 
 	// Sort literals, to bring similar strings nearer to each other.
 	if len(sub) > 2 {
-		allHaveLeadingString := true
+		// Only sort where all subexpressions have a leading string and all have the same case-sensitivity.
+		okToSort := true
+		_, firstFold := p.leadingString(sub[0])
 		for i := range sub {
-			if x, _ := p.leadingString(sub[i]); x == nil {
-				allHaveLeadingString = false
+			istr, iflags := p.leadingString(sub[i])
+			if istr == nil || iflags != firstFold {
+				okToSort = false
 				break
 			}
 		}
-		if allHaveLeadingString {
+		if okToSort {
 			// Where one string is a prefix of the other we want to keep the ordering the same,
 			// because earlier choices are preferred. So use stable sort, and only compare up
 			// to the length of the shorter string.


### PR DESCRIPTION
Internally, case-insensitive matches are held in upper-case, so (?i:aa) would sort before `a`. Rather than try to figure out what is ok, just avoid sorting lists of alternates where case-folding differs.