### PR TITLE
Run fuzz tests on ubuntu-latest

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -11,7 +11,7 @@ jobs:
         include:
           - fuzz: FuzzMatchString_FuzzingInputs
           - fuzz: FuzzMatchString_FuzzingRegexpsAndInputs
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/setup-go@v5
         with:


### PR DESCRIPTION
The previous setting of ubuntu-20.04 has no runners available.